### PR TITLE
Option to insert space after autocompletion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ function inCodeBlock(editor: Editor, cursor: EditorPosition): boolean {
 			inCodeBlock = !inCodeBlock;
 		}
 	}
-	
+
 	return inCodeBlock;
 }
 
@@ -32,7 +32,7 @@ export default class TAPlugin extends Plugin {
 		await this.loadWordTrie();
 		this.settingsTab = new TASettingsTab(this.app, this);
 		this.addSettingTab(this.settingsTab);
-		
+
 		// Event listeners for autocomplete triggers, keydowns, and extensions
 		this.registerEvent(this.app.workspace.on('editor-change', this.handleEditorChange.bind(this)));
 		this.registerEvent(this.app.workspace.on('editor-menu', this.handleContextMenu.bind(this)));
@@ -121,7 +121,7 @@ export default class TAPlugin extends Plugin {
 			.filter((w: string) => w !== word);
 
 		if (suggestions.length > 0) {
-			updateSuggestions(suggestions, editor);
+			updateSuggestions(suggestions, editor, this.settings);
 		} else {
 			destroyTAUI(); // Should never happen but is a safety check
 		}
@@ -131,7 +131,7 @@ export default class TAPlugin extends Plugin {
 	handleContextMenu(menu: Menu, editor: Editor) {
 		const selectedText = editor.getSelection()?.trim();
 		if (selectedText && /^.*$/.test(selectedText)) {
-			menu.addItem(item => 
+			menu.addItem(item =>
 				item.setTitle(`Add "${selectedText}" to custom dictionary`)
 					.onClick(async () => {
 						if (!this.settings.customDict.includes(selectedText)) {
@@ -175,7 +175,7 @@ export default class TAPlugin extends Plugin {
 				destroyTAUI();
 				return;
 			}
-			if (evt.key === 'ArrowDown') index = (index + 1) % items.length; 
+			if (evt.key === 'ArrowDown') index = (index + 1) % items.length;
 			if (evt.key === 'ArrowUp') index = (index - 1 + items.length) % items.length;
 
 			items.forEach((item, i) => item.classList.toggle('active', i === index)); // Updates which suggestion is tagged active

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -6,18 +6,18 @@ import { destroyTAUI } from './ui';
 
 export interface TASettings {
     enabled: boolean; // Autocomplete enabling
-    addSpace: boolean; // Add Space enabling
     language: string; // Language support
     maxSuggestions: number; // Max number of proposed suggestions at a time
+    addSpace: boolean; // Add space enabling
     customDict: string[];
     // latex: boolean; // LaTeX support
 }
 
 export const DEFAULT_SETTINGS: TASettings = {
     enabled: true,
-    addSpace: false,
     language: 'English',
     maxSuggestions: 3,
+    addSpace: false,
     customDict: [],
     // latex: false,
 }
@@ -46,18 +46,6 @@ export class TASettingsTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     }));
 
-        // Add space setting
-        new Setting(containerEl)
-            .setName('Add space after Autocomplete')
-            .setDesc('Enable/disable adding space at the end of the autocompleted word.')
-            .addToggle(toggle =>
-                toggle.setValue(this.plugin.settings.addSpace)
-                    .onChange(async val => {
-                        this.plugin.settings.addSpace = val;
-                        if (!val) destroyTAUI;
-                        await this.plugin.saveSettings();
-                    }));
-
         // Language setting
         new Setting(containerEl)
             .setName('Language')
@@ -80,6 +68,17 @@ export class TASettingsTab extends PluginSettingTab {
                     .setDynamicTooltip()
                     .onChange(async (val: number) => {
                         this.plugin.settings.maxSuggestions = val;
+                        await this.plugin.saveSettings();
+                    }));
+
+        new Setting(containerEl)
+            .setName('Add space after Autocomplete')
+            .setDesc('Enable/disable adding space at the end of the autocompleted word.')
+            .addToggle(toggle =>
+                toggle.setValue(this.plugin.settings.addSpace)
+                    .onChange(async val => {
+                        this.plugin.settings.addSpace = val;
+                        if (!val) destroyTAUI;
                         await this.plugin.saveSettings();
                     }));
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -72,8 +72,8 @@ export class TASettingsTab extends PluginSettingTab {
                     }));
 
         new Setting(containerEl)
-            .setName('Add space after Autocomplete')
-            .setDesc('Enable/disable adding space at the end of the autocompleted word.')
+            .setName('Space terminator after autocomplete')
+            .setDesc('Enable/disable adding space terminator to autocompleted words.')
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.addSpace)
                     .onChange(async val => {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -6,14 +6,16 @@ import { destroyTAUI } from './ui';
 
 export interface TASettings {
     enabled: boolean; // Autocomplete enabling
+    addSpace: boolean; // Add Space enabling
     language: string; // Language support
     maxSuggestions: number; // Max number of proposed suggestions at a time
     customDict: string[];
     // latex: boolean; // LaTeX support
 }
 
-export const DEFAULT_SETTINGS : TASettings = {
+export const DEFAULT_SETTINGS: TASettings = {
     enabled: true,
+    addSpace: false,
     language: 'English',
     maxSuggestions: 3,
     customDict: [],
@@ -40,6 +42,18 @@ export class TASettingsTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.enabled)
                     .onChange(async val => {
                         this.plugin.settings.enabled = val;
+                        if (!val) destroyTAUI;
+                        await this.plugin.saveSettings();
+                    }));
+
+        // Add space setting
+        new Setting(containerEl)
+            .setName('Add space after Autocomplete')
+            .setDesc('Enable/disable adding space at the end of the autocompleted word.')
+            .addToggle(toggle =>
+                toggle.setValue(this.plugin.settings.addSpace)
+                    .onChange(async val => {
+                        this.plugin.settings.addSpace = val;
                         if (!val) destroyTAUI;
                         await this.plugin.saveSettings();
                     }));
@@ -102,7 +116,7 @@ export class TASettingsTab extends PluginSettingTab {
                     scrollContainer.classList.remove('show');
                 }, 1000);
             });
-            
+
             this.plugin.settings.customDict.forEach((word: string, index: number) => {
                 const row = new Setting(scrollContainer)
                     .setDesc(word)

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -1,5 +1,6 @@
 import { ViewPlugin, ViewUpdate, PluginValue } from '@codemirror/view';
 import { Editor, EditorRange } from 'obsidian';
+import { TASettings } from './settings';
 
 let dropdownEl: HTMLUListElement | null = null;
 
@@ -12,7 +13,7 @@ interface CodeMirrorEditor extends Editor {
                 };
             };
         };
-        coordsAtPos: (pos: number) => { left: number; top: number; bottom: number} | null;
+        coordsAtPos: (pos: number) => { left: number; top: number; bottom: number } | null;
     };
 }
 
@@ -31,8 +32,8 @@ export function createTAUI() {
                     const lineStart = doc.lineAt(cursor).from;
                     const line = doc.lineAt(cursor).text;
                     const beforeCursor = line.substring(0, cursor - lineStart); // Current line up to cursor
-		            const afterCursor = line.substring(cursor - lineStart);
-                    
+                    const afterCursor = line.substring(cursor - lineStart);
+
                     // Destroy dropdown if cursor is in a word or before punctation
                     if (/^[\w.,;:!?'"()\[\]{}\-_+=<>@#$%^&*]/.test(afterCursor)) {
                         destroyTAUI();
@@ -66,7 +67,7 @@ export function destroyTAUI() {
     dropdownEl = null;
 }
 
-export function updateSuggestions(suggestions: string[], editor: Editor) {
+export function updateSuggestions(suggestions: string[], editor: Editor, settings: TASettings) {
     destroyTAUI();
 
     const cm = (editor as CodeMirrorEditor).cm;
@@ -86,8 +87,11 @@ export function updateSuggestions(suggestions: string[], editor: Editor) {
             const beforeCursor = line.substring(0, cursor.ch);
             const match = beforeCursor.match(/(\b[\w']+)$/);
             if (match) {
+                if (settings.addSpace) {
+                    suggestion += " ";
+                }
                 editor.replaceRange(
-                    suggestion, 
+                    suggestion,
                     { line: cursor.line, ch: cursor.ch - match[1].length }, // start position (line, position in line)
                     cursor // end position (line, position in line)
                 );

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -87,9 +87,7 @@ export function updateSuggestions(suggestions: string[], editor: Editor, setting
             const beforeCursor = line.substring(0, cursor.ch);
             const match = beforeCursor.match(/(\b[\w']+)$/);
             if (match) {
-                if (settings.addSpace) {
-                    suggestion += " ";
-                }
+                if (settings.addSpace) suggestion += " ";
                 editor.replaceRange(
                     suggestion,
                     { line: cursor.line, ch: cursor.ch - match[1].length }, // start position (line, position in line)


### PR DESCRIPTION
Adds an option in the plugin settings to add a space after inserting the autocompleted word.
The option is disabled by default.